### PR TITLE
Only auto-expand returned entities if not side-loading.

### DIFF
--- a/functions/Get-Group.ps1
+++ b/functions/Get-Group.ps1
@@ -73,6 +73,8 @@ function Get-Group {
     }
 
     $result = Invoke-Method @params
-    $result | Select-Object -Expand $key
 
+    if (-not $PSBoundParameters.ContainsKey('SideLoad')) {
+        $result | Select-Object -Expand $key
+    }
 }

--- a/functions/Get-GroupMembership.ps1
+++ b/functions/Get-GroupMembership.ps1
@@ -91,6 +91,8 @@ function Get-GroupMembership {
     }
 
     $result = Invoke-Method @params
-    $result | Select-Object -Expand $key
 
+    if (-not $PSBoundParameters.ContainsKey('SideLoad')) {
+        $result | Select-Object -Expand $key
+    }
 }

--- a/functions/Get-Ticket.ps1
+++ b/functions/Get-Ticket.ps1
@@ -141,7 +141,9 @@ function Get-Ticket {
     }
 
     $result = Invoke-Method @params
-    $result | Select-Object -Expand $key
 
+    if (-not $PSBoundParameters.ContainsKey('SideLoad')) {
+        $result | Select-Object -Expand $key
+    }
 }
 

--- a/functions/Get-User.ps1
+++ b/functions/Get-User.ps1
@@ -137,6 +137,8 @@ function Get-User {
     }
 
     $result = Invoke-Method @params
-    $result | Select-Object -Expand $key
 
+    if (-not $PSBoundParameters.ContainsKey('SideLoad')) {
+        $result | Select-Object -Expand $key
+    }
 }


### PR DESCRIPTION
Side-loaded entities are lost when auto-expanding as they are returned as separate top level entities rather than part of the primary entities