### PR TITLE
Rename `ApiKey` to `ApiToken` to match the terminology Zendesk doco uses

### DIFF
--- a/functions/Connect-.ps1
+++ b/functions/Connect-.ps1
@@ -26,11 +26,12 @@ function Connect- {
         [String]
         $Username,
 
-        # Zendesk API key retrieved from https://<organization>.zendesk.com/agent/admin/api/settings
+        # Zendesk API token retrieved from https://<organization>.zendesk.com/agent/admin/api/settings
         [Parameter(Mandatory = $true)]
+        [Alias('ApiKey')]
         [ValidateNotNullOrEmpty()]
         [SecureString]
-        $ApiKey
+        $ApiToken
     )
 
     $Script:Context = Get-Connection @PSBoundParameters

--- a/functions/Get-Connection.ps1
+++ b/functions/Get-Connection.ps1
@@ -25,17 +25,18 @@ function Get-Connection {
         [String]
         $Username,
 
-        # Zendesk API key retrieved from https://<organization>.zendesk.com/agent/admin/api/settings
+        # Zendesk API token retrieved from https://<organization>.zendesk.com/agent/admin/api/settings
         [Parameter(Mandatory = $true)]
+        [Alias('ApiKey')]
         [ValidateNotNullOrEmpty()]
         [SecureString]
-        $ApiKey
+        $ApiToken
     )
 
     $context = [PSCustomObject]@{
         Organization = $Organization
         BaseUrl      = "https://$Organization.zendesk.com"
-        Credential   = [System.Management.Automation.PSCredential]::New("$Username/token", $ApiKey)
+        Credential   = [System.Management.Automation.PSCredential]::New("$Username/token", $ApiToken)
         User         = $null
     }
 


### PR DESCRIPTION
`ApiKey` added as an alias for backward compatibility.